### PR TITLE
fix: check if there are supported apps on android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mybdesign.RNPassKit">
+    
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="application/vnd.apple.pkpass" />
+        </intent>
+    </queries>
+
 </manifest>


### PR DESCRIPTION
Android has done some changes on API 30 or something and now we need some kind of permissions for our application to search for other apps.

Here's their explanation in docs: https://developer.android.com/training/package-visibility/declaring